### PR TITLE
Allowing to pass floating numbers

### DIFF
--- a/lib/bot/index.js
+++ b/lib/bot/index.js
@@ -81,7 +81,7 @@ app.post('/', function (req, res, next) {
 })
 
 app.post('/', function (req, res, next) {
-  var match = req.body.text.match(/^iou\s+<@([0-9A-Z]+)>\s+[\$€]?([0-9]+\.?[0-9]*)(?:\s+(.+))?$/i)
+  var match = req.body.text.match(/^iou\s+<@([0-9A-Z]+)>\s+[\$€]?([0-9]+(?:\.[0-9]+)?)(?:\s+(.+))?$/i)
 
   if (!match) return next()
 
@@ -105,7 +105,7 @@ app.post('/', function (req, res, next) {
 })
 
 app.post('/', function (req, res, next) {
-  var match = req.body.text.match(/^ask\s+<@([0-9A-Z]+)>\s+[\$€]?([0-9]+\.?[0-9]*)(?:\s+(.+))?$/i)
+  var match = req.body.text.match(/^ask\s+<@([0-9A-Z]+)>\s+[\$€]?([0-9]+(?:\.[0-9]+)?)(?:\s+(.+))?$/i)
 
   if (!match) return next()
 

--- a/lib/bot/index.js
+++ b/lib/bot/index.js
@@ -81,7 +81,7 @@ app.post('/', function (req, res, next) {
 })
 
 app.post('/', function (req, res, next) {
-  var match = req.body.text.match(/^iou\s+<@([0-9A-Z]+)>\s+[\$€]?([0-9]+)(?:\s+(.+))?$/i)
+  var match = req.body.text.match(/^iou\s+<@([0-9A-Z]+)>\s+[\$€]?([0-9]+\.?[0-9]*)(?:\s+(.+))?$/i)
 
   if (!match) return next()
 
@@ -105,7 +105,7 @@ app.post('/', function (req, res, next) {
 })
 
 app.post('/', function (req, res, next) {
-  var match = req.body.text.match(/^ask\s+<@([0-9A-Z]+)>\s+[\$€]?([0-9]+)(?:\s+(.+))?$/i)
+  var match = req.body.text.match(/^ask\s+<@([0-9A-Z]+)>\s+[\$€]?([0-9]+\.?[0-9]*)(?:\s+(.+))?$/i)
 
   if (!match) return next()
 

--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -12,7 +12,8 @@ var NoteSchema = module.exports = new Schema({
 })
 
 NoteSchema.path('amount').validate(function (value) {
-  return Number.isSafeInteger(value)
+//  return Number.isSafeInteger(value)
+  return Number.isFinite(value);
 }, '`amount` must be a real number.')
 
 NoteSchema.pre('save', function (next) {
@@ -21,6 +22,16 @@ NoteSchema.pre('save', function (next) {
   }
   next()
 })
+
+// Getter
+NoteSchema.path('amount').get(function(num) {
+  return Number((num / 100).toFixed(2));
+});
+
+// Setter
+NoteSchema.path('amount').set(function(num) {
+  return num * 100;
+});
 
 NoteSchema.plugin(timestamps)
 NoteSchema.plugin(softDelete)


### PR DESCRIPTION
Currently, when we issue a `iou @user 12.34` bot complains.

This PR provides support for decimal amount

IMPORTANT note : the change makes previously stored notes incompatible with the new ones as I keep storing amount as number (I only multiply/divide this value by 100, making previously stored values incompatible with new ones)

To be 100%  accurate, I would have to provide a migration mongo script to multiply previous notes' amount by 100, but I don't have enough knowledge into mongoose to know if this is easily possible or not.